### PR TITLE
Add cpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Perl is distributed under a dual licence : [Artistic Licence](https://opensour
 - :moneybag: [Corelist](http://corelist.rpee.be/) - A web interface of the tool **corelist** used to know _core modules_ shipped in a specific version of Perl.
 - :older_man: [CPAN.pm](https://metacpan.org/pod/CPAN) - Venerable CPAN modules installer, part of core distribution, fully configurable ([github](https://github.com/andk/cpanpm))
 - :frog: [CPAN Plus](https://github.com/jib/cpanplus-devel) - API to access CPAN mirrors (+ CPAN modules installer)
+- :fast_forward: [cpm](https://github.com/skaji/cpm) - A fast, parallel CPAN module installer
 
 ## :dromedary_camel: General
 - :man_with_turban: [Perl Monks](https://www.perlmonks.org/) - The Perl _Stack Overflow_


### PR DESCRIPTION
cpm seems like a worthy addition to the list.  It's a fast, parallel CPAN module installer that feels like it brings Perl module installation into modern times.  Apparently, the plan is to merge it with cpanm for cpanm version 2.0. 